### PR TITLE
Fixed Chin-up Champs scoring

### DIFF
--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/begin.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/begin.mcfunction
@@ -24,4 +24,5 @@ scoreboard players set timer= 41scores 0
 
 execute as @a[tag=ingame] run attribute @s generic.jump_strength base set 1
 
-scoreboard players set @a[tag=ingame] 41jump 0
+# Reset the scores 1 tick after start due to is_on_ground returning true for the first run of repeating if the player jumps in the countdown
+schedule function games:41/reset_scores 1t

--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/display.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/display.mcfunction
@@ -77,10 +77,10 @@ execute as @a[tag=ingame,scores={41score=8},team=red] run team modify displaylin
 execute as @a[tag=ingame,scores={41score=8},team=green] run team modify displayline5 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"green","with":[{"text":"8","color":"green","bold":true,"underlined":true}]}
 execute as @a[tag=ingame,scores={41score=8},team=orange] run team modify displayline2 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"gold","with":[{"text":"8","color":"gold","bold":true,"underlined":true}]}
 
-execute as @a[tag=ingame,scores={41score=9},team=blue] run team modify displayline11 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"#0088ff","with":[{"text":"9","color":"#0088ff","bold":true,"underlined":true}]}
-execute as @a[tag=ingame,scores={41score=9},team=red] run team modify displayline8 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"red","with":[{"text":"9","color":"red","bold":true,"underlined":true}]}
-execute as @a[tag=ingame,scores={41score=9},team=green] run team modify displayline5 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"green","with":[{"text":"9","color":"green","bold":true,"underlined":true}]}
-execute as @a[tag=ingame,scores={41score=9},team=orange] run team modify displayline2 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"gold","with":[{"text":"9","color":"gold","bold":true,"underlined":true}]}
+execute as @a[tag=ingame,scores={41score=9},team=blue] run team modify displayline11 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"#0088ff","with":[{"text":"9","color":"#0088ff","bold":true,"underlined":true}]}
+execute as @a[tag=ingame,scores={41score=9},team=red] run team modify displayline8 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"red","with":[{"text":"9","color":"red","bold":true,"underlined":true}]}
+execute as @a[tag=ingame,scores={41score=9},team=green] run team modify displayline5 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"green","with":[{"text":"9","color":"green","bold":true,"underlined":true}]}
+execute as @a[tag=ingame,scores={41score=9},team=orange] run team modify displayline2 prefix {"translate":"scoreboard.ChinUpChamps.1","color":"gold","with":[{"text":"9","color":"gold","bold":true,"underlined":true}]}
 
 execute as @a[tag=ingame,scores={41score=10},team=blue] run team modify displayline11 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"#0088ff","with":[{"text":"10","color":"#0088ff","bold":true,"underlined":true}]}
 execute as @a[tag=ingame,scores={41score=10},team=red] run team modify displayline8 prefix {"translate":"scoreboard.ChinUpChamps.2","color":"red","with":[{"text":"10","color":"red","bold":true,"underlined":true}]}

--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/give_score.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/give_score.mcfunction
@@ -5,53 +5,53 @@
 tag @a remove scored
 
 # Resets the max= score to -1 to be compared
-scoreboard players set max= 19score -1
+scoreboard players set max= 41score -1
 
 # Sets the max= score to the highest value of a players score
-scoreboard players operation max= 19score > @a[tag=ingame] 19score
+scoreboard players operation max= 41score > @a[tag=ingame] 41score
 
 # Checks if any player has the same score as the max= score, if so it means they have the highest score and gives them the 1st and scored tag
-execute as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 1st
-execute as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
+execute as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 1st
+execute as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
 
 # Stores the number of players who have been given a score into the scored= score
-execute store result score scored= 19score if entity @a[tag=ingame,tag=scored]
+execute store result score scored= 41score if entity @a[tag=ingame,tag=scored]
 
 # Resets the max= score to -1 to be compared
-scoreboard players set max= 19score -1
+scoreboard players set max= 41score -1
 
 # Sets the max= score to the highest value of a players score
-scoreboard players operation max= 19score > @a[tag=ingame,tag=!scored] 19score
+scoreboard players operation max= 41score > @a[tag=ingame,tag=!scored] 41score
 
 # Checks if any player has the same score as the max= score. Also checks how many players havent been scored yet, and gives the appropiate tag
-execute if score scored= 19score matches 1 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 2nd
-execute if score scored= 19score matches 1 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
-execute if score scored= 19score matches 2 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 3rd
-execute if score scored= 19score matches 2 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
-execute if score scored= 19score matches 3 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 4th
-execute if score scored= 19score matches 3 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
+execute if score scored= 41score matches 1 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 2nd
+execute if score scored= 41score matches 1 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
+execute if score scored= 41score matches 2 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 3rd
+execute if score scored= 41score matches 2 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
+execute if score scored= 41score matches 3 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 4th
+execute if score scored= 41score matches 3 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
 
 # Stores the number of players who have been given a score into the scored= score
-execute store result score scored= 19score if entity @a[tag=ingame,tag=scored]
+execute store result score scored= 41score if entity @a[tag=ingame,tag=scored]
 
 # Resets the max= score to -1 to be compared
-scoreboard players set max= 19score -1
+scoreboard players set max= 41score -1
 
 # Sets the max= score to the highest value of a players score
-scoreboard players operation max= 19score > @a[tag=ingame,tag=!scored] 19score
+scoreboard players operation max= 41score > @a[tag=ingame,tag=!scored] 41score
 
 # Checks if any player has the same score as the max= score. Also checks how many players havent been scored yet, and gives the appropiate tag
-execute if score scored= 19score matches 2 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 3rd
-execute if score scored= 19score matches 2 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
-execute if score scored= 19score matches 3 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add 4th
-execute if score scored= 19score matches 3 as @a[tag=ingame] if score @s 19score = max= 19score run tag @s add scored
+execute if score scored= 41score matches 2 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 3rd
+execute if score scored= 41score matches 2 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
+execute if score scored= 41score matches 3 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add 4th
+execute if score scored= 41score matches 3 as @a[tag=ingame] if score @s 41score = max= 41score run tag @s add scored
 
 # Stores the number of players who have been given a score into the scored= score
-execute store result score scored= 19score if entity @a[tag=ingame,tag=scored]
+execute store result score scored= 41score if entity @a[tag=ingame,tag=scored]
 
 # If all players except one have been scored, then the final player is 4th
-execute if score scored= 19score matches 3 run tag @a[tag=ingame,tag=!scored] add 4th
-execute if score scored= 19score matches 3 run tag @a[tag=ingame,tag=!scored] add scored
+execute if score scored= 41score matches 3 run tag @a[tag=ingame,tag=!scored] add 4th
+execute if score scored= 41score matches 3 run tag @a[tag=ingame,tag=!scored] add scored
 
 # Resets the scored tags
 tag @a[tag=ingame] remove scored

--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/land.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/land.mcfunction
@@ -2,8 +2,8 @@ tag @s remove 41jump
 
 attribute @s generic.gravity base set 0.08
 
-function games:41/display
 scoreboard players add @s 41score 1
+function games:41/display
 
 execute as @s[team=blue] as @e[type=text_display,tag=41timer,tag=blue] run function games:41/set_display
 execute as @s[team=red] as @e[type=text_display,tag=41timer,tag=red] run function games:41/set_display

--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/reset_scores.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/reset_scores.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set @a[tag=ingame] 41jump 0
+scoreboard players set @a[tag=ingame] 41score 0
+
+function games:41/display
+execute as @a[team=blue] as @e[type=text_display,tag=41timer,tag=blue] run function games:41/set_display
+execute as @a[team=red] as @e[type=text_display,tag=41timer,tag=red] run function games:41/set_display
+execute as @a[team=green] as @e[type=text_display,tag=41timer,tag=green] run function games:41/set_display
+execute as @a[team=orange] as @e[type=text_display,tag=41timer,tag=orange] run function games:41/set_display

--- a/world/datapacks/WiiPartyDatapack/data/games/function/41/set_display.mcfunction
+++ b/world/datapacks/WiiPartyDatapack/data/games/function/41/set_display.mcfunction
@@ -1,3 +1,5 @@
+execute if score @p[tag=ingame] 41score matches 0 run data merge entity @s {text:'{"bold":true,"color":"#FFD000","text":"00"}'}
+
 execute if score @p[tag=ingame] 41score matches 1 run data merge entity @s {text:'{"bold":true,"color":"#FFD000","text":"01"}'}
 
 execute if score @p[tag=ingame] 41score matches 2 run data merge entity @s {text:'{"bold":true,"color":"#FFD000","text":"02"}'}


### PR DESCRIPTION
Fixed the text display under the players and the display side scoreboard being offset from eachother, fixed formatting of the side scoreboard when its set to 9, and the end score now works. This commit (hopefully) fixes these problems.